### PR TITLE
docs(INT-002): Mark IRC ingestion as completed (post-merge sync)

### DIFF
--- a/.docs/06-tasks.md
+++ b/.docs/06-tasks.md
@@ -234,7 +234,7 @@ Phase 1 delivers Telegram + IRC integrations, core inbox operations, authenticat
 | ID | Task | Status | Priority | Assignee | Dependencies | Acceptance Criteria | Project Item ID | Issue ID |
 |----|------|--------|----------|----------|--------------|---------------------|-----------------|----------|
 | INT-001 | Create IRC connector (server connection, authentication, channel joins) | **Done** (PR #254 merged) | P0 | Backend | BE-001 | Connects to IRC server, authenticates, joins configured channels | PVTI_lAHOAB4wV84BNGcwzgkHa_U | 128 |
-| INT-002 | Implement IRC message ingestion (inbound messages → inbox) | In Review (PR #257) | P0 | Backend | BE-002, INT-001 | Inbound messages create conversations/messages in DB (PR #257) | PVTI_lAHOAB4wV84BNGcwzgkHbAU | 129 |
+| INT-002 | Implement IRC message ingestion (inbound messages → inbox) | **Done** (PR #257 merged) | P0 | Backend | BE-002, INT-001 | Inbound messages create conversations/messages in DB; WebSocket `message.received` backlog-aware; tests passing | PVTI_lAHOAB4wV84BNGcwzgkHbAU | 129 |
 | INT-003 | Implement IRC message delivery (outbound messages → IRC channel) | Ready | P0 | Backend | BE-010, INT-001 | Messages sent to IRC channel, status updated to sent/failed | PVTI_lAHOAB4wV84BNGcwzgkHbB4 | 130 |
 | INT-004 | Implement IRC auto-reconnect with exponential backoff (1s → 60s max, 5 attempts) | Not Started | P0 | Backend | INT-001 | Disconnects trigger reconnect attempts with backoff | PVTI_lAHOAB4wV84BNGcwzgj_824 | 60 |
 | INT-005 | Implement IRC connection status tracking (connected/retrying/disconnected) | Not Started | P0 | Backend | INT-004 | Status stored in DB, exposed via WebSocket | PVTI_lAHOAB4wV84BNGcwzgj_6NE | 59 |

--- a/.docs/plans/00-INDEX.md
+++ b/.docs/plans/00-INDEX.md
@@ -23,7 +23,7 @@ Historical execution plans, phase packets, and session notes are removed post-MV
 | Task | Status | Dependencies | Notes |
 |------|--------|--------------|-------|
 | **INT-001** (IRC Connector) | ✅ **COMPLETED** (Feb 15, 2026) | — | Code merged to dev; production-ready IRC server connection with proper handshake, event-driven reconnect, security hardening |
-| **INT-002** (IRC Ingestion) | ⏳ **IN REVIEW** (PR #257) | INT-001 | Inbound messages → conversations/messages in DB; atomic upsert, auto-reopen resolved conversations, WebSocket events |
+| **INT-002** (IRC Ingestion) | ✅ **COMPLETED** (PR #257 merged) | INT-001 | Inbound messages → conversations/messages in DB; atomic upsert, auto-reopen resolved conversations, WebSocket events (backlog-aware) |
 | **INT-003** (IRC Delivery) | ⏳ **READY** | INT-001 | Outbound messages → IRC channel |
 | **INT-004-014** (IRC Infra) | ⏳ **READY** | INT-003 | Connection status, config, auto-reconnect, environment management |
 


### PR DESCRIPTION
Update documentation tracking after PR #257 merge.

- `.docs/06-tasks.md`: INT-002 marked Done (PR #257 merged)
- `.docs/plans/00-INDEX.md`: INT-002 marked Completed

Related:
- PR #257 merged (INT-002 implementation)