### PR TITLE
docs: ADRs for Bun + K3s/Helm deployment and adapters

### DIFF
--- a/.docs/01-product-specification.md
+++ b/.docs/01-product-specification.md
@@ -24,7 +24,7 @@
 ## 1. Product Overview
 
 ### Concept
-**YACC (Yet Another Chat Client)** is a cloud-hosted, single-tenant omni-channel chat platform that centralizes social communications (MVP Phase 1: Telegram groups/channels and IRC) into one unified inbox. Built with React, Node.js, PostgreSQL, and deployed to Cloudflare R2 + CDN for frontend assets and file storage, with backend on VPS.
+**YACC (Yet Another Chat Client)** is a cloud-hosted, single-tenant omni-channel chat platform that centralizes social communications (MVP Phase 1: Telegram groups/channels and IRC) into one unified inbox. Built with React, Node.js, PostgreSQL, and deployed to Cloudflare R2 + CDN for frontend assets and file storage, with backend deployed to K3s via Helm (ADR-019).
 
 **Initial Release (Phase 1 MVP)**: Single-tenant deployment with unified inbox, auth, messaging (Telegram/IRC), collaboration features, routing rules, and notifications.  
 **Post-MVP**: Multi-tenant support, additional channels (WhatsApp/WeChat/Meta/X), and vault-based credential management.

--- a/.docs/03-implementation-guide.md
+++ b/.docs/03-implementation-guide.md
@@ -113,10 +113,10 @@ After message stored:
 | **Message Queue** | Redis + BullMQ | Outbound message retry queue |
 | **File Storage** | Cloudflare R2 | Raw payloads, attachments, re-hosted files |
 | **Email** | Nodemailer / SendGrid | Password reset emails |
-| **Hosting** | VPS (single-tenant MVP) | Node API + SPA on S3/Cloudflare |
+| **Hosting** | K3s + Helm (single-tenant MVP) | Backend runs on K3s; deploy via Helm; dependencies via Helm |
 | **Testing** | Playwright | E2E testing |
 | **Testing** | Vitest | Unit & integration tests (native ESM, 18.8% faster) |
-| **Package Manager** | pnpm | Monorepo management with workspaces |
+| **Package Manager** | pnpm | Monorepo management with workspaces (Bun migration tracked separately) |
 
 ---
 
@@ -778,8 +778,8 @@ Push to main
 GitHub Actions: backend-deploy.yml
   ├── Build Docker image (multi-stage)
   ├── Push to Docker registry
-  ├── SSH to VPS
-  ├── Pull image + restart container
+  ├── Helm upgrade --install (to K3s)
+  ├── Rollout status check
   ↓
 API live at https://api.example.com
 ```

--- a/.docs/05-quick-reference.md
+++ b/.docs/05-quick-reference.md
@@ -13,6 +13,14 @@ See [01-product-specification.md](./01-product-specification.md) for full scope 
 
 ---
 
+## Deployment & CI/CD
+
+- Target runtime: K3s (Kubernetes)
+- Installer: Helm (app charts + dependencies like PostgreSQL/Redis)
+- Architecture decision: `.docs/adr/ADR-019-k3s-helm-cicd-deployment.md`
+
+---
+
 ## Package Manager: pnpm
 
 YACC uses **pnpm** for monorepo management. 

--- a/.docs/06-tasks.md
+++ b/.docs/06-tasks.md
@@ -1,6 +1,6 @@
 # 06. Issues & User stories
 
-**Last Updated**: February 19, 2026  
+**Last Updated**: February 20, 2026  
 **Status**: ⏳ Phase 1 in progress (IRC admin endpoints); ✅ Phase 2 COMPLETE; ✅ MVP stage  
 **Current focus**: Post-MVP backlog / hardening (GitHub Project is source of truth)  
 **Governance**: ADR-003, ADR-014, ADR-015, GOV-026
@@ -188,6 +188,20 @@ Phase 1 delivers Telegram + IRC integrations, core inbox operations, authenticat
 | DEV-001b | Fix messageRetryWorker.ts import paths and module references | Not Started | P0 | Backend | DEV-001a | Worker imports resolved; tests pass | PVTI_lAHOAB4wV84BNGcwzgldpQ4 | 174 |
 | DEV-001c | Fix TypeScript moduleResolution and tsconfig issues | Not Started | P0 | Backend | DEV-001a | TypeScript config consistent across packages; no resolution errors | PVTI_lAHOAB4wV84BNGcwzgldpRI | 175 |
 | DEV-001d | Standardize logger usage across backend config files | Not Started | P0 | Backend | DEV-001c | Logging uses approved patterns; no console logging in config/infrastructure | PVTI_lAHOAB4wV84BNGcwzgldpRU | 176 |
+| DEV-002 | Consolidate auth services into authentication.service.ts (login/logout/getSession + password reset/validation) | Not Started | P1 | Backend | BE-003, BE-004 | Create `services/authentication.service.ts`; update `controllers/auth.controller.ts` to call it; remove redundant auth-only service files; keep `services/authorization.service.ts` scoped to authZ; tests + lint pass | - | - |
+| DEV-003 | Create gateway-exchange.ts for inbound + outbound orchestration | Not Started | P0 | Backend | - | Add `services/gateway-exchange.ts` as the single orchestration point for inbound/outbound message flow (persist, audit, rules hook, retry enqueue, typed WS emit); no platform-specific mapping in this file; existing flows updated to call gateway-exchange; tests pass | - | - |
+| DEV-004 | Move platform adapters into infrastructure (ADR-005 Addendum-2) | Not Started | P0 | Backend | DEV-003 | Migrate `connectors/*` platform translation to `infrastructure/*.adapter.ts` (e.g. `irc.adapter.ts`, `telegram.adapter.ts`); adapters contain SDK/protocol + mapping only; adapters DO NOT import `services/*` or write DB/emit WS; compilation passes | - | - |
+| DEV-005 | Refactor inbound pipeline to remove service dependencies from adapters | Not Started | P0 | Backend | DEV-004 | IRC inbound no longer calls `irc-ingestion.service.ts` from adapter; instead adapter emits normalized inbound events and `gateway-exchange.ts` handles persistence + side effects; add similar wiring for Telegram inbound when implemented; tests updated/added | - | - |
+| DEV-006 | Standardize adapter registration and outbound dispatch through gateway-exchange | Not Started | P1 | Backend | DEV-003, DEV-004 | `integrations-runtime.service.ts` registers adapters consistently; `message.service.ts` dispatches outbound via `gateway-exchange.ts` (gateway calls adapter send); connectorManager usage updated or replaced; retry worker path remains compatible; tests pass | - | - |
+| DEV-007 | Move backend unit tests out of src/__tests__ into tests/ mirror structure | Not Started | P0 | Backend | - | All backend tests live under `packages/backend/tests/` (same-level as `src/`); folder structure mirrors `src/` (e.g. `tests/services/...`); feature/task tests allowed in `tests/tasks/<TASK-ID>.spec.ts`; remove all `packages/backend/src/**/__tests__/` and `packages/backend/src/**/*.{spec,test}.ts`; test runner config updated if needed; `pnpm --filter @yacc/backend test` passes | - | - |
+| DEV-008 | Add guardrail to prevent new src/__tests__ tests | Not Started | P1 | Backend | DEV-007 | Add a CI/lint check (script or lint rule) that fails if any files exist under `packages/backend/src/**/__tests__/` or match `packages/backend/src/**/*.{spec,test}.ts`; developer docs updated; pipeline passes | - | - |
+| DEV-009 | ADR-018: Bun runtime migration (monorepo) | Not Started | P0 | Architect | - | ADR-018 approved; scope (runtime vs package manager) clarified; rollback plan documented; risks captured | - | - |
+| DEV-010 | Migrate monorepo installs to Bun workspaces | Not Started | P0 | Backend | DEV-009 | `bun install` works at repo root; workspace links resolve; pnpm usage removed or explicitly scoped; lockfile and CI caching updated; `turbo` tasks still run | - | - |
+| DEV-011 | Run backend on Bun in dev and production Docker | Not Started | P0 | Backend | DEV-010 | Backend starts via Bun (local + Docker); health smoke test passes; decorator stack works; no Node runtime requirement for prod container | - | - |
+| DEV-012 | CI/CD update for Bun runtime | Not Started | P1 | Backend | DEV-011 | GitHub Actions uses Bun install/cache; backend/frontend/common build and tests pass in CI; rollback path verified | - | - |
+| DEV-013 | ADR-019: Standardize CI/CD to K3s + Helm | Not Started | P0 | Architect | - | ADR-019 approved; docs updated (technology + implementation + quick reference); environment assumptions documented; rollback approach captured | - | - |
+| DEV-014 | Create Helm charts for YACC + dependencies (MVP) | Not Started | P0 | Backend | DEV-013 | Helm charts exist for backend (and frontend if deployed in-cluster); PostgreSQL + Redis installed via Helm; values separated per env; `helm upgrade --install` is idempotent; smoke deploy works on K3s | - | - |
+| DEV-015 | Update CI pipeline to deploy to K3s using Helm | Not Started | P0 | Backend | DEV-014 | GitHub Actions deploy job uses Helm; deploys to staging namespace; rollback documented; no kubectl imperative drift; pipeline passes | - | - |
 
 ### Frontend Tasks
 

--- a/.docs/adr/ADR-005-infrastructure-config-pattern.addendum-2-external-adapters-in-infrastructure.md
+++ b/.docs/adr/ADR-005-infrastructure-config-pattern.addendum-2-external-adapters-in-infrastructure.md
@@ -1,0 +1,99 @@
+# ADR-005-Addendum-2: External Platform Adapters in Infrastructure
+
+**Date:** 2026-02-20  
+**Status:** Accepted  
+**Parent ADR:** ADR-005 (Simple Infrastructure and Config Pattern)  
+**Type:** Architecture Refinement
+
+---
+
+## Context
+
+YACC integrates with external messaging platforms (e.g., IRC, Telegram). We want:
+
+- Fewer file jumps when working on integrations
+- A single orchestration point for message exchange (inbound + outbound)
+- Platform-specific translation/transformation to remain the adapter/connector responsibility
+
+ADR-005 currently constrains `packages/backend/src/infrastructure/` to client initialization and discourages business logic there. However, adapter code is boundary translation and protocol/SDK interaction, not YACC business workflows.
+
+---
+
+## Decision
+
+### 1) Expand the scope of `infrastructure/` to include external platform adapter code
+
+**Allowed in** `packages/backend/src/infrastructure/`:
+
+- Platform SDK/protocol interaction code (HTTP calls, socket wiring)
+- Platform-specific request/response mapping (raw payload -> normalized DTO)
+- Input/output sanitization required by the external protocol (e.g., IRC message sanitization)
+- Retryable error classification and mapping to YACC error shapes (but not scheduling retries)
+
+**Not allowed in** `packages/backend/src/infrastructure/`:
+
+- Database reads/writes
+- Routing rules evaluation
+- Audit logging decisions
+- WebSocket emission
+- Any workflow that mutates YACC state beyond returning normalized DTOs
+
+Those orchestration concerns remain in the gateway service (application/service layer), e.g. `packages/backend/src/services/gateway-exchange.ts`.
+
+### 2) Keep infrastructure flat (no subfolders)
+
+This addendum does not re-introduce nested infra folders. External adapters must live at the same level as other infra files.
+
+**Naming convention (recommended):**
+
+- `packages/backend/src/infrastructure/irc.adapter.ts`
+- `packages/backend/src/infrastructure/telegram.adapter.ts`
+
+### 3) Gateway composes adapters; adapters do not compose services
+
+Dependency direction:
+
+- `services/gateway-exchange.ts` -> `infrastructure/<platform>.adapter.ts`
+- `infrastructure/<platform>.adapter.ts` may depend on config + low-level libraries/SDKs
+- `infrastructure/<platform>.adapter.ts` must not import `services/*`
+
+---
+
+## Consequences
+
+### Pros
+
+- Easier discoverability: external integration boundary code lives in one place
+- Clear separation: adapters translate; gateway orchestrates
+- Consistent layering: external-specific complexity does not leak into services
+
+### Cons / Risks
+
+- Infrastructure folder becomes broader; requires discipline to keep orchestration out
+- Potential confusion between "client" vs "adapter" responsibilities
+
+### Guardrails
+
+- Adapters must be pure translation + SDK/protocol interaction (no DB, WS, audit)
+- Gateway is the only place that persists messages/conversations and triggers side effects
+
+---
+
+## Related Documents
+
+- ADR-005: Simple Infrastructure and Config Pattern
+- ADR-005-Addendum-1: Flat Infrastructure + DI Pattern
+
+---
+
+## Approval
+
+**Architect Approval:**
+- Name: Enterprise/Solution Architect
+- Date: 2026-02-20
+- Status: ✅ APPROVED
+
+**Product Owner Approval:**
+- Name: _________________
+- Date: _________________
+- Comments: _________________

--- a/.docs/adr/ADR-005-infrastructure-config-pattern.md
+++ b/.docs/adr/ADR-005-infrastructure-config-pattern.md
@@ -458,6 +458,8 @@ export const someService = SomeService.getInstance();
 - **ADR-004**: Logging and Observability Strategy
 - **03-implementation-guide.md**: System architecture and folder structure
 - **PR #152**: BE-003 Authentication implementation (contains violations)
+- **ADR-005-Addendum-1**: Flat Infrastructure + DI Pattern
+- **ADR-005-Addendum-2**: External Platform Adapters in Infrastructure
 
 ---
 

--- a/.docs/adr/ADR-018-bun-runtime-migration.md
+++ b/.docs/adr/ADR-018-bun-runtime-migration.md
@@ -1,0 +1,95 @@
+**Status:** Proposed  
+**Date:** 2026-02-20  
+**Deciders:** Enterprise Architect + Product Owner  
+**Related:** ADR-013 (backend build bundling esbuild), ADR-007 (vitest)
+
+---
+
+# Architecture Decision Record
+
+## Title
+Adopt Bun Runtime (and Bun Workspaces) for the YACC Monorepo
+
+## Context
+
+We want to migrate YACC to the Bun runtime while keeping the current monorepo structure:
+
+- `packages/backend/`
+- `packages/frontend/`
+- `packages/common/`
+
+Current backend assumptions include Node.js 18+ runtime and a backend build pipeline documented in ADR-013.
+
+Key goals:
+
+- Keep monorepo layout (no structural rewrite)
+- Reduce runtime/tooling friction (faster installs and execution)
+- Keep deployability to K3s (Helm-based deployments)
+- Maintain compatibility with decorator-heavy backend stack (routing-controllers + reflect-metadata)
+- Keep Turborepo orchestration (optional but preferred)
+
+## Decision
+
+### 1) Runtime
+
+Adopt **Bun** as the primary runtime for:
+
+- Running the backend service in dev and production
+- Running backend scripts (build/test/lint) where compatible
+
+### 2) Monorepo
+
+Keep the existing monorepo package boundaries and adopt **Bun workspaces** for dependency installation/linking.
+
+Turborepo remains supported; it is runtime-agnostic and can continue to orchestrate tasks.
+
+### 3) Backend build pipeline
+
+This ADR supersedes the "keep runtime as Node.js 18+" constraint in ADR-013.
+
+We keep ADR-013's build approach (tsc -> esbuild) initially to minimize risk. The runtime used to execute the built artifact becomes:
+
+- `bun dist/index.js` (or equivalent Bun start command)
+
+Any future simplification (e.g., Bun-native TS execution in dev) is explicitly out of scope for this ADR and should be evaluated after the migration stabilizes.
+
+### 4) Testing
+
+Keep Vitest (ADR-007) initially.
+
+Rationale: migration scope is already large; switching test runners to `bun test` can be evaluated later as a separate ADR/task.
+
+## Consequences
+
+### Pros
+
+- Monorepo can remain unchanged; workspaces continue to link local packages
+- Potential faster install and script execution
+- Single runtime choice across environments (local + Docker)
+
+### Cons / Risks
+
+- Bun compatibility gaps may surface (ESM edge cases, Node API parity differences, tooling expectations)
+- CI/CD pipeline changes (lockfile, caching strategy, install commands)
+- Deployment image changes (base image, entrypoint)
+
+### Compatibility guardrails
+
+- Keep the backend build output as a JS artifact (`dist/index.js`) and run that in Bun
+- Do not change core framework stack during migration (Express, routing-controllers, Drizzle)
+- Rollback must remain possible within one PR (return to Node + pnpm)
+
+## Migration Plan (High-Level)
+
+1. Add Bun runtime to CI and local toolchain; validate `bun --version`
+2. Add Bun workspace configuration and lockfile; update install scripts
+3. Update backend start command to run with Bun (dev + prod)
+4. Update Dockerfile to use Bun runtime image
+5. Update GitHub Actions caching and commands
+6. Run full test suite and smoke run backend
+
+## Rollback Plan
+
+- Revert lockfile/tooling changes (restore pnpm usage)
+- Restore backend start commands to Node
+- Restore CI/Docker base image to Node

--- a/.docs/adr/ADR-019-k3s-helm-cicd-deployment.md
+++ b/.docs/adr/ADR-019-k3s-helm-cicd-deployment.md
@@ -1,0 +1,65 @@
+**Status:** Accepted  
+**Date:** 2026-02-20  
+**Deciders:** Enterprise Architect + Product Owner  
+**Related:** ADR-016 (06-tasks as task map), ADR-018 (Bun runtime migration)
+
+---
+
+# Architecture Decision Record
+
+## Title
+Adopt K3s + Helm as CI/CD Deployment Target (MVP and Beyond)
+
+## Context
+
+YACC currently references a "single VPS Docker" deployment model in multiple documents. We are standardizing the delivery pipeline and runtime target to Kubernetes, specifically:
+
+- **K3s** as the Kubernetes distribution (lightweight, suitable for single-tenant MVP)
+- **Helm** as the packaging/deployment mechanism
+
+We want a repeatable CI/CD flow where:
+
+- The application (backend and optionally frontend) is deployed via Helm charts
+- Platform dependencies are installed via Helm (e.g., PostgreSQL, Redis)
+- Environments (dev/staging/prod) are reproducible and auditable
+
+## Decision
+
+1. **CI/CD target is K3s.** All deploy pipelines assume a K3s cluster.
+2. **Helm is the standard installer.** Helm installs both:
+   - YACC application charts
+   - Supporting dependencies (PostgreSQL, Redis, etc.)
+3. **Dependency policy (MVP default):** dependencies are installed via Helm into the cluster unless explicitly documented as managed external services.
+4. **Artifacts:** build artifacts remain container images; deployment uses `helm upgrade --install`.
+
+## Consequences
+
+### Pros
+
+- Repeatable deployments with versioned manifests and values
+- Easier promotion (staging -> prod) via Helm values
+- Enables horizontal scaling and standardized ops practices
+
+### Cons / Risks
+
+- Additional operational complexity vs single Docker host
+- Requires cluster lifecycle management (ingress, certs, storage)
+- Helm chart discipline required (no ad-hoc kubectl changes)
+
+## Guardrails
+
+- No secrets in repo: use Kubernetes Secrets sealed/externalized per environment
+- Helm charts must be idempotent and support rollback
+- Postgres/Redis values must be explicitly documented (storage, resource requests/limits)
+
+## Approval
+
+**Architect Approval:**
+- Name: Enterprise/Solution Architect
+- Date: 2026-02-20
+- Status: ✅ APPROVED
+
+**Product Owner Approval:**
+- Name: _________________
+- Date: _________________
+- Comments: _________________

--- a/.docs/architecture/001-technology-architecture.md
+++ b/.docs/architecture/001-technology-architecture.md
@@ -33,16 +33,21 @@ Define the approved technology stack, runtime environments, deployment model, an
 ## Deployment Architecture (MVP)
 ### Targets
 - Frontend: AWS S3 + CloudFront
-- Backend: Docker on a single VPS instance
+- Backend: K3s (Kubernetes) cluster
+
+### Delivery / CI/CD
+- Deployment target: K3s
+- Installer: Helm (application charts + dependencies)
+- Reference: ADR-019
 
 ### Mermaid – High-Level Deployment
 ```mermaid
 flowchart LR
   U[Users] --> CF[CloudFront]
   CF --> S3[S3 Static Frontend]
-  U --> API[Backend API - VPS Docker]
-  API --> PG[(PostgreSQL)]
-  API --> R[(Redis)]
+  U --> API[Backend API - K3s]
+  API --> PG[(PostgreSQL - Helm)]
+  API --> R[(Redis - Helm)]
   API --> R2[(Cloudflare R2)]
 ```
 
@@ -58,3 +63,4 @@ flowchart LR
 ## References
 - ADR-004 logging strategy: `.docs/adr/ADR-004-logging-strategy.md`
 - ADR-005 config/infrastructure pattern: `.docs/adr/ADR-005-infrastructure-config-pattern.md`
+- ADR-019 K3s + Helm CI/CD target: `.docs/adr/ADR-019-k3s-helm-cicd-deployment.md`

--- a/.docs/governance/GOV-012-BE-006-phase4-platform-integration.md
+++ b/.docs/governance/GOV-012-BE-006-phase4-platform-integration.md
@@ -431,7 +431,7 @@ describe('Message retry failure flow', () => {
 
 - **No database migrations required** (uses existing schema)
 - **No configuration changes required** (uses existing env vars)
-- **No infrastructure changes required** (single VPS deployment)
+- **No infrastructure changes required** (assumes K3s + Helm baseline per ADR-019)
 - **WebSocket gateway already initialized** (in BE-006 Phase 1-3)
 - **Message queue service already in place** (from previous phases)
 - **Immediate deployment possible** after PR merge

--- a/.docs/observability-slo.md
+++ b/.docs/observability-slo.md
@@ -10,7 +10,7 @@
 
 | Component | SLO | Metric | Target | Notes |
 |-----------|-----|--------|--------|-------|
-| **Inbox API** | Availability | Uptime | 99.5% | Single VPS, no redundancy (Phase 2: multi-region) |
+| **Inbox API** | Availability | Uptime | 99.5% | Single K3s cluster, no redundancy (Phase 2: multi-region) |
 | **Inbox API** | Latency (p50) | Response time | <100ms | GET /conversations, GET /conversations/:id |
 | **Inbox API** | Latency (p99) | Response time | <500ms | Maximum acceptable latency at 99th percentile |
 | **Message Send** | Success rate | Success/Total | 95% | After 3 retries (DLQ captures failures) |


### PR DESCRIPTION
## Why
We are standardizing (1) integration adapter placement, (2) a proposed Bun runtime migration, and (3) CI/CD + deployment target as K3s with Helm.

## What changed
- Added ADR-005 Addendum-2 allowing external platform adapter code under `infrastructure/` with strict guardrails (no DB/WS/audit/rules).
- Added ADR-018 draft for Bun runtime + Bun workspaces migration (keeps current monorepo shape).
- Added ADR-019 establishing K3s + Helm as the CI/CD deployment target and Helm-managed dependencies.
- Updated core docs and task tracker to reflect K3s/Helm direction and migration work items.

## Docs updated
- `.docs/01-product-specification.md`
- `.docs/03-implementation-guide.md`
- `.docs/05-quick-reference.md`
- `.docs/06-tasks.md`
- `.docs/architecture/001-technology-architecture.md`
- `.docs/observability-slo.md`
- `.docs/governance/GOV-012-BE-006-phase4-platform-integration.md`

## ADRs
- `.docs/adr/ADR-005-infrastructure-config-pattern.addendum-2-external-adapters-in-infrastructure.md`
- `.docs/adr/ADR-018-bun-runtime-migration.md`
- `.docs/adr/ADR-019-k3s-helm-cicd-deployment.md`