### PR TITLE
fix: correct API paths in tests and documentation (issue #269)

### DIFF
--- a/.docs/02-api-and-data-model.md
+++ b/.docs/02-api-and-data-model.md
@@ -875,7 +875,7 @@ Resets user password using a valid reset token.
 
 ### Conversations
 
-#### `GET /conversations`
+#### `GET /api/conversations`
 **Query**: `page`, `pageSize`, `channel`, `tag`, `assignee`, `status`, `priority`, `search`, `dateFrom`, `dateTo`, `unread`
 
 **Response:**
@@ -890,7 +890,7 @@ Resets user password using a valid reset token.
 
 ---
 
-#### `GET /conversations/:id`
+#### `GET /api/conversations/:id`
 **Response:**
 ```json
 { "data": { /* Conversation Detail model */ } }
@@ -898,7 +898,7 @@ Resets user password using a valid reset token.
 
 ---
 
-#### `PATCH /conversations/:id`
+#### `PATCH /api/conversations/:id`
 **Request:**
 ```json
 {
@@ -966,7 +966,7 @@ Bulk action endpoint for assign, tag, or status update on multiple conversations
 
 ### Messages
 
-#### `GET /conversations/:id/messages`
+#### `GET /api/conversations/:id/messages`
 **Query**: `page`, `pageSize`
 
 **Response:**
@@ -981,7 +981,7 @@ Bulk action endpoint for assign, tag, or status update on multiple conversations
 
 ---
 
-#### `POST /conversations/:id/messages`
+#### `POST /api/conversations/:id/messages`
 **Request:**
 ```json
 {
@@ -999,7 +999,7 @@ Bulk action endpoint for assign, tag, or status update on multiple conversations
 
 ---
 
-#### `POST /conversations/:id/messages/:msgId/retry`
+#### `POST /api/conversations/:id/messages/:msgId/retry`
 **Response:**
 ```json
 { "data": { /* Message model (updated status) */ } }
@@ -1009,7 +1009,7 @@ Bulk action endpoint for assign, tag, or status update on multiple conversations
 
 ---
 
-#### `GET /conversations/:id/messages/:messageId/status`
+#### `GET /api/conversations/:id/messages/:messageId/status`
 **Response:**
 ```json
 {
@@ -1289,7 +1289,7 @@ Bulk action endpoint for assign, tag, or status update on multiple conversations
 
 ### Attachments
 
-#### `POST /conversations/:id/attachments`
+#### `POST /api/conversations/:id/attachments`
 **Request**: `multipart/form-data` with `file` field
 
 **Response:**

--- a/packages/backend/tests/BE-009-010-message-api.spec.ts
+++ b/packages/backend/tests/BE-009-010-message-api.spec.ts
@@ -6,7 +6,7 @@ import { dbClient } from '../src/infrastructure/db.client.js';
 import { messages, type Message } from '../src/schemas/message.schema.js';
 import { eq } from 'drizzle-orm';
 
-describe('BE-009/010: Message API (GET /conversations/:id/messages, POST /conversations/:id/messages)', () => {
+describe('BE-009/010: Message API (GET /api/conversations/:id/messages, POST /api/conversations/:id/messages)', () => {
   let app: Express;
   let authToken: string;
   let testUserId: string;
@@ -54,16 +54,16 @@ describe('BE-009/010: Message API (GET /conversations/:id/messages, POST /conver
     }
   });
 
-  describe('GET /conversations/:id/messages - Message Retrieval', () => {
+  describe('GET /api/conversations/:id/messages - Message Retrieval', () => {
     it('should return 401 without authorization token', async () => {
-      const res = await request(app).get(`/conversations/${conversationId}/messages`);
+      const res = await request(app).get(`/api/conversations/${conversationId}/messages`);
 
       expect(res.status).toBe(401);
     });
 
     it('should return empty messages for new conversation', async () => {
       const res = await request(app)
-        .get(`/conversations/${conversationId}/messages`)
+        .get(`/api/conversations/${conversationId}/messages`)
         .set('Authorization', `Bearer ${authToken}`);
 
       expect(res.status).toBe(200);
@@ -76,7 +76,7 @@ describe('BE-009/010: Message API (GET /conversations/:id/messages, POST /conver
     it('should return 404 for non-existent conversation', async () => {
       const fakeId = '00000000-0000-0000-0000-000000000000';
       const res = await request(app)
-        .get(`/conversations/${fakeId}/messages`)
+        .get(`/api/conversations/${fakeId}/messages`)
         .set('Authorization', `Bearer ${authToken}`);
 
       expect(res.status).toBe(404);
@@ -85,7 +85,7 @@ describe('BE-009/010: Message API (GET /conversations/:id/messages, POST /conver
 
     it('should return 400 for invalid page parameter', async () => {
       const res = await request(app)
-        .get(`/conversations/${conversationId}/messages?page=invalid`)
+        .get(`/api/conversations/${conversationId}/messages?page=invalid`)
         .set('Authorization', `Bearer ${authToken}`);
 
       expect(res.status).toBe(400);
@@ -94,7 +94,7 @@ describe('BE-009/010: Message API (GET /conversations/:id/messages, POST /conver
 
     it('should return 400 for invalid limit parameter', async () => {
       const res = await request(app)
-        .get(`/conversations/${conversationId}/messages?limit=150`)
+        .get(`/api/conversations/${conversationId}/messages?limit=150`)
         .set('Authorization', `Bearer ${authToken}`);
 
       expect(res.status).toBe(400);
@@ -103,7 +103,7 @@ describe('BE-009/010: Message API (GET /conversations/:id/messages, POST /conver
 
     it('should return 400 for invalid direction parameter', async () => {
       const res = await request(app)
-        .get(`/conversations/${conversationId}/messages?direction=invalid`)
+        .get(`/api/conversations/${conversationId}/messages?direction=invalid`)
         .set('Authorization', `Bearer ${authToken}`);
 
       expect(res.status).toBe(400);
@@ -124,7 +124,7 @@ describe('BE-009/010: Message API (GET /conversations/:id/messages, POST /conver
       }
 
       const res = await request(app)
-        .get(`/conversations/${conversationId}/messages?page=1&limit=5`)
+        .get(`/api/conversations/${conversationId}/messages?page=1&limit=5`)
         .set('Authorization', `Bearer ${authToken}`);
 
       expect(res.status).toBe(200);
@@ -135,7 +135,7 @@ describe('BE-009/010: Message API (GET /conversations/:id/messages, POST /conver
 
       // Test page 2
       const res2 = await request(app)
-        .get(`/conversations/${conversationId}/messages?page=2&limit=5`)
+        .get(`/api/conversations/${conversationId}/messages?page=2&limit=5`)
         .set('Authorization', `Bearer ${authToken}`);
 
       expect(res2.status).toBe(200);
@@ -170,7 +170,7 @@ describe('BE-009/010: Message API (GET /conversations/:id/messages, POST /conver
         .returning();
 
       const inboundRes = await request(app)
-        .get(`/conversations/${conversationId}/messages?direction=inbound`)
+        .get(`/api/conversations/${conversationId}/messages?direction=inbound`)
         .set('Authorization', `Bearer ${authToken}`);
 
       expect(inboundRes.status).toBe(200);
@@ -178,7 +178,7 @@ describe('BE-009/010: Message API (GET /conversations/:id/messages, POST /conver
       expect(inboundMessages.every((m: Message) => m.direction === 'inbound')).toBe(true);
 
       const outboundRes = await request(app)
-        .get(`/conversations/${conversationId}/messages?direction=outbound`)
+        .get(`/api/conversations/${conversationId}/messages?direction=outbound`)
         .set('Authorization', `Bearer ${authToken}`);
 
       expect(outboundRes.status).toBe(200);
@@ -188,7 +188,7 @@ describe('BE-009/010: Message API (GET /conversations/:id/messages, POST /conver
 
     it('should return messages ordered chronologically (oldest first)', async () => {
       const res = await request(app)
-        .get(`/conversations/${conversationId}/messages?limit=100`)
+        .get(`/api/conversations/${conversationId}/messages?limit=100`)
         .set('Authorization', `Bearer ${authToken}`);
 
       expect(res.status).toBe(200);
@@ -206,7 +206,7 @@ describe('BE-009/010: Message API (GET /conversations/:id/messages, POST /conver
   describe('POST /conversations/:id/messages - Message Sending', () => {
     it('should return 401 without authorization token', async () => {
       const res = await request(app)
-        .post(`/conversations/${conversationId}/messages`)
+        .post(`/api/conversations/${conversationId}/messages`)
         .send({ body: 'Test message' });
 
       expect(res.status).toBe(401);
@@ -214,7 +214,7 @@ describe('BE-009/010: Message API (GET /conversations/:id/messages, POST /conver
 
     it('should send a message successfully as user', async () => {
       const res = await request(app)
-        .post(`/conversations/${conversationId}/messages`)
+        .post(`/api/conversations/${conversationId}/messages`)
         .set('Authorization', `Bearer ${authToken}`)
         .send({ body: 'Hello, World!' });
 
@@ -230,7 +230,7 @@ describe('BE-009/010: Message API (GET /conversations/:id/messages, POST /conver
 
     it('should send a message successfully as manager', async () => {
       const res = await request(app)
-        .post(`/conversations/${conversationId}/messages`)
+        .post(`/api/conversations/${conversationId}/messages`)
         .set('Authorization', `Bearer ${managerToken}`)
         .send({ body: 'Manager message' });
 
@@ -241,7 +241,7 @@ describe('BE-009/010: Message API (GET /conversations/:id/messages, POST /conver
 
     it('should reject empty message body', async () => {
       const res = await request(app)
-        .post(`/conversations/${conversationId}/messages`)
+        .post(`/api/conversations/${conversationId}/messages`)
         .set('Authorization', `Bearer ${authToken}`)
         .send({ body: '' });
 
@@ -252,7 +252,7 @@ describe('BE-009/010: Message API (GET /conversations/:id/messages, POST /conver
     it('should reject message exceeding max length (10000 chars)', async () => {
       const longBody = 'a'.repeat(10001);
       const res = await request(app)
-        .post(`/conversations/${conversationId}/messages`)
+        .post(`/api/conversations/${conversationId}/messages`)
         .set('Authorization', `Bearer ${authToken}`)
         .send({ body: longBody });
 
@@ -263,7 +263,7 @@ describe('BE-009/010: Message API (GET /conversations/:id/messages, POST /conver
     it('should accept message at max length boundary (10000 chars)', async () => {
       const maxBody = 'a'.repeat(10000);
       const res = await request(app)
-        .post(`/conversations/${conversationId}/messages`)
+        .post(`/api/conversations/${conversationId}/messages`)
         .set('Authorization', `Bearer ${authToken}`)
         .send({ body: maxBody });
 
@@ -274,7 +274,7 @@ describe('BE-009/010: Message API (GET /conversations/:id/messages, POST /conver
     it('should return 404 for non-existent conversation', async () => {
       const fakeId = '00000000-0000-0000-0000-000000000000';
       const res = await request(app)
-        .post(`/conversations/${fakeId}/messages`)
+        .post(`/api/conversations/${fakeId}/messages`)
         .set('Authorization', `Bearer ${authToken}`)
         .send({ body: 'Test message' });
 
@@ -284,7 +284,7 @@ describe('BE-009/010: Message API (GET /conversations/:id/messages, POST /conver
 
     it('should reject admin user from sending messages (role-based access control)', async () => {
       const res = await request(app)
-        .post(`/conversations/${conversationId}/messages`)
+        .post(`/api/conversations/${conversationId}/messages`)
         .set('Authorization', `Bearer ${adminToken}`)
         .send({ body: 'Admin message' });
 
@@ -294,7 +294,7 @@ describe('BE-009/010: Message API (GET /conversations/:id/messages, POST /conver
 
     it('should reject message with missing body', async () => {
       const res = await request(app)
-        .post(`/conversations/${conversationId}/messages`)
+        .post(`/api/conversations/${conversationId}/messages`)
         .set('Authorization', `Bearer ${authToken}`)
         .send({});
 
@@ -304,7 +304,7 @@ describe('BE-009/010: Message API (GET /conversations/:id/messages, POST /conver
 
     it('should persist message to database', async () => {
       const sendRes = await request(app)
-        .post(`/conversations/${conversationId}/messages`)
+        .post(`/api/conversations/${conversationId}/messages`)
         .set('Authorization', `Bearer ${authToken}`)
         .send({ body: 'Persisted message' });
 
@@ -328,7 +328,7 @@ describe('BE-009/010: Message API (GET /conversations/:id/messages, POST /conver
       for (let i = 0; i < 5; i++) {
         promises.push(
           request(app)
-            .post(`/conversations/${conversationId}/messages`)
+            .post(`/api/conversations/${conversationId}/messages`)
             .set('Authorization', `Bearer ${authToken}`)
             .send({ body: `Concurrent message ${i}` })
         );
@@ -341,7 +341,7 @@ describe('BE-009/010: Message API (GET /conversations/:id/messages, POST /conver
 
       // Verify all messages were persisted
       const msgRes = await request(app)
-        .get(`/conversations/${conversationId}/messages?limit=100`)
+        .get(`/api/conversations/${conversationId}/messages?limit=100`)
         .set('Authorization', `Bearer ${authToken}`);
 
       expect(msgRes.body.total).toBeGreaterThanOrEqual(5);
@@ -349,7 +349,7 @@ describe('BE-009/010: Message API (GET /conversations/:id/messages, POST /conver
 
     it('should set sender name from user email', async () => {
       const res = await request(app)
-        .post(`/conversations/${conversationId}/messages`)
+        .post(`/api/conversations/${conversationId}/messages`)
         .set('Authorization', `Bearer ${authToken}`)
         .send({ body: 'Message with sender name' });
 

--- a/packages/backend/tests/BE-011-message-status-tracking.spec.ts
+++ b/packages/backend/tests/BE-011-message-status-tracking.spec.ts
@@ -48,7 +48,7 @@ describe('BE-011: Message Status Tracking (MessageStatusTracker Integration)', (
     it('should return message status after sending', async () => {
       // Send a message
       const sendResponse = await request(app)
-        .post(`/conversations/${conversationId}/messages`)
+        .post(`/api/conversations/${conversationId}/messages`)
         .set('Authorization', `Bearer ${authToken}`)
         .send({ body: 'Test message for status check' });
 
@@ -60,7 +60,7 @@ describe('BE-011: Message Status Tracking (MessageStatusTracker Integration)', (
 
       // Get message status
       const statusResponse = await request(app)
-        .get(`/conversations/${conversationId}/messages/${messageId}/status`)
+        .get(`/api/conversations/${conversationId}/messages/${messageId}/status`)
         .set('Authorization', `Bearer ${authToken}`);
 
       expect(statusResponse.status).toBe(200);
@@ -74,7 +74,7 @@ describe('BE-011: Message Status Tracking (MessageStatusTracker Integration)', (
 
     it('should return 404 if conversation does not exist', async () => {
       const statusResponse = await request(app)
-        .get('/conversations/nonexistent/messages/msg123/status')
+        .get('/api/conversations/nonexistent/messages/msg123/status')
         .set('Authorization', `Bearer ${authToken}`);
 
       expect(statusResponse.status).toBe(404);
@@ -85,7 +85,7 @@ describe('BE-011: Message Status Tracking (MessageStatusTracker Integration)', (
 
     it('should return 404 if message does not exist', async () => {
       const statusResponse = await request(app)
-        .get(`/conversations/${conversationId}/messages/nonexistent/status`)
+        .get(`/api/conversations/${conversationId}/messages/nonexistent/status`)
         .set('Authorization', `Bearer ${authToken}`);
 
       expect(statusResponse.status).toBe(404);
@@ -101,7 +101,7 @@ describe('BE-011: Message Status Tracking (MessageStatusTracker Integration)', (
 
       // Send a message in the first conversation
       const sendResponse = await request(app)
-        .post(`/conversations/${conversationId}/messages`)
+        .post(`/api/conversations/${conversationId}/messages`)
         .set('Authorization', `Bearer ${authToken}`)
         .send({ body: 'Test message' });
 
@@ -110,7 +110,7 @@ describe('BE-011: Message Status Tracking (MessageStatusTracker Integration)', (
 
       // Try to get status from the other conversation
       const statusResponse = await request(app)
-        .get(`/conversations/${otherConversationId}/messages/${messageId}/status`)
+        .get(`/api/conversations/${otherConversationId}/messages/${messageId}/status`)
         .set('Authorization', `Bearer ${authToken}`);
 
       expect(statusResponse.status).toBe(404);
@@ -124,7 +124,7 @@ describe('BE-011: Message Status Tracking (MessageStatusTracker Integration)', (
 
     it('should require authentication', async () => {
       const sendResponse = await request(app)
-        .post(`/conversations/${conversationId}/messages`)
+        .post(`/api/conversations/${conversationId}/messages`)
         .set('Authorization', `Bearer ${authToken}`)
         .send({ body: 'Test message' });
 
@@ -132,7 +132,7 @@ describe('BE-011: Message Status Tracking (MessageStatusTracker Integration)', (
       const messageId = sendResponse.body.id;
 
       const statusResponse = await request(app)
-        .get(`/conversations/${conversationId}/messages/${messageId}/status`);
+        .get(`/api/conversations/${conversationId}/messages/${messageId}/status`);
 
       expect(statusResponse.status).toBe(403);
     });
@@ -141,7 +141,7 @@ describe('BE-011: Message Status Tracking (MessageStatusTracker Integration)', (
   describe('Message Status Transitions', () => {
     it('should track status as pending -> sent for successful send', async () => {
       const sendResponse = await request(app)
-        .post(`/conversations/${conversationId}/messages`)
+        .post(`/api/conversations/${conversationId}/messages`)
         .set('Authorization', `Bearer ${authToken}`)
         .send({ body: 'Message for status tracking' });
 
@@ -156,7 +156,7 @@ describe('BE-011: Message Status Tracking (MessageStatusTracker Integration)', (
 
       // Status should transition to sent
       const statusResponse = await request(app)
-        .get(`/conversations/${conversationId}/messages/${messageId}/status`)
+        .get(`/api/conversations/${conversationId}/messages/${messageId}/status`)
         .set('Authorization', `Bearer ${authToken}`);
 
       expect(statusResponse.status).toBe(200);
@@ -165,7 +165,7 @@ describe('BE-011: Message Status Tracking (MessageStatusTracker Integration)', (
 
     it('should update message timestamps on status change', async () => {
       const sendResponse = await request(app)
-        .post(`/conversations/${conversationId}/messages`)
+        .post(`/api/conversations/${conversationId}/messages`)
         .set('Authorization', `Bearer ${authToken}`)
         .send({ body: 'Message for timestamp tracking' });
 
@@ -178,7 +178,7 @@ describe('BE-011: Message Status Tracking (MessageStatusTracker Integration)', (
 
       // Get updated message
       const statusResponse = await request(app)
-        .get(`/conversations/${conversationId}/messages/${messageId}/status`)
+        .get(`/api/conversations/${conversationId}/messages/${messageId}/status`)
         .set('Authorization', `Bearer ${authToken}`);
 
       expect(statusResponse.status).toBe(200);
@@ -192,7 +192,7 @@ describe('BE-011: Message Status Tracking (MessageStatusTracker Integration)', (
     it('should return message status in conversation message list', async () => {
       // Send a message
       const sendResponse = await request(app)
-        .post(`/conversations/${conversationId}/messages`)
+        .post(`/api/conversations/${conversationId}/messages`)
         .set('Authorization', `Bearer ${authToken}`)
         .send({ body: 'Message for list status check' });
 
@@ -204,7 +204,7 @@ describe('BE-011: Message Status Tracking (MessageStatusTracker Integration)', (
 
       // Get messages list
       const listResponse = await request(app)
-        .get(`/conversations/${conversationId}/messages`)
+        .get(`/api/conversations/${conversationId}/messages`)
         .set('Authorization', `Bearer ${authToken}`);
 
       expect(listResponse.status).toBe(200);
@@ -219,7 +219,7 @@ describe('BE-011: Message Status Tracking (MessageStatusTracker Integration)', (
     it('should preserve message status across multiple queries', async () => {
       // Send a message
       const sendResponse = await request(app)
-        .post(`/conversations/${conversationId}/messages`)
+        .post(`/api/conversations/${conversationId}/messages`)
         .set('Authorization', `Bearer ${authToken}`)
         .send({ body: 'Message for status persistence' });
 
@@ -231,7 +231,7 @@ describe('BE-011: Message Status Tracking (MessageStatusTracker Integration)', (
 
       // Query status endpoint
       const statusResponse1 = await request(app)
-        .get(`/conversations/${conversationId}/messages/${messageId}/status`)
+        .get(`/api/conversations/${conversationId}/messages/${messageId}/status`)
         .set('Authorization', `Bearer ${authToken}`);
 
       expect(statusResponse1.status).toBe(200);
@@ -241,7 +241,7 @@ describe('BE-011: Message Status Tracking (MessageStatusTracker Integration)', (
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       const statusResponse2 = await request(app)
-        .get(`/conversations/${conversationId}/messages/${messageId}/status`)
+        .get(`/api/conversations/${conversationId}/messages/${messageId}/status`)
         .set('Authorization', `Bearer ${authToken}`);
 
       expect(statusResponse2.status).toBe(200);
@@ -257,7 +257,7 @@ describe('BE-011: Message Status Tracking (MessageStatusTracker Integration)', (
     it('manager should be able to send messages and track status', async () => {
       // Send a message as manager
       const sendResponse = await request(app)
-        .post(`/conversations/${conversationId}/messages`)
+        .post(`/api/conversations/${conversationId}/messages`)
         .set('Authorization', `Bearer ${managerToken}`)
         .send({ body: 'Message from manager' });
 
@@ -271,7 +271,7 @@ describe('BE-011: Message Status Tracking (MessageStatusTracker Integration)', (
 
       // Check status
       const statusResponse = await request(app)
-        .get(`/conversations/${conversationId}/messages/${messageId}/status`)
+        .get(`/api/conversations/${conversationId}/messages/${messageId}/status`)
         .set('Authorization', `Bearer ${managerToken}`);
 
       expect(statusResponse.status).toBe(200);
@@ -283,7 +283,7 @@ describe('BE-011: Message Status Tracking (MessageStatusTracker Integration)', (
     it('should track status independently for multiple messages', async () => {
       // Send first message
       const msg1Response = await request(app)
-        .post(`/conversations/${conversationId}/messages`)
+        .post(`/api/conversations/${conversationId}/messages`)
         .set('Authorization', `Bearer ${authToken}`)
         .send({ body: 'First message' });
 
@@ -292,7 +292,7 @@ describe('BE-011: Message Status Tracking (MessageStatusTracker Integration)', (
 
       // Send second message
       const msg2Response = await request(app)
-        .post(`/conversations/${conversationId}/messages`)
+        .post(`/api/conversations/${conversationId}/messages`)
         .set('Authorization', `Bearer ${authToken}`)
         .send({ body: 'Second message' });
 
@@ -304,11 +304,11 @@ describe('BE-011: Message Status Tracking (MessageStatusTracker Integration)', (
 
       // Check both statuses
       const status1Response = await request(app)
-        .get(`/conversations/${conversationId}/messages/${messageId1}/status`)
+        .get(`/api/conversations/${conversationId}/messages/${messageId1}/status`)
         .set('Authorization', `Bearer ${authToken}`);
 
       const status2Response = await request(app)
-        .get(`/conversations/${conversationId}/messages/${messageId2}/status`)
+        .get(`/api/conversations/${conversationId}/messages/${messageId2}/status`)
         .set('Authorization', `Bearer ${authToken}`);
 
       expect(status1Response.status).toBe(200);
@@ -323,7 +323,7 @@ describe('BE-011: Message Status Tracking (MessageStatusTracker Integration)', (
   describe('Message metadata and status', () => {
     it('should return complete message data with status via GET endpoint', async () => {
       const sendResponse = await request(app)
-        .post(`/conversations/${conversationId}/messages`)
+        .post(`/api/conversations/${conversationId}/messages`)
         .set('Authorization', `Bearer ${authToken}`)
         .send({ body: 'Test message with full metadata' });
 
@@ -335,7 +335,7 @@ describe('BE-011: Message Status Tracking (MessageStatusTracker Integration)', (
 
       // Get full message
       const messageResponse = await request(app)
-        .get(`/conversations/${conversationId}/messages?limit=1`)
+        .get(`/api/conversations/${conversationId}/messages?limit=1`)
         .set('Authorization', `Bearer ${authToken}`);
 
       expect(messageResponse.status).toBe(200);


### PR DESCRIPTION
## Summary

This PR fixes issue #269 by correcting a path prefix mismatch between backend API tests, documentation, and the actual controller implementation.

### Problem

- Backend API spec tests (BE-009, BE-011) were returning 404 errors because they called paths like `/conversations/:id/messages`
- The actual controller decorators were at `/api/conversations/:id/messages` (with `/api` prefix)
- Documentation (`.docs/02-api-and-data-model.md`) showed paths without `/api` prefix, inconsistent with implementation
- This mismatch blocked confidence in test results and hid potential regressions

### Changes Made

1. **Updated test paths** (BE-009, BE-011):
   - Changed all calls from `/conversations/*` to `/api/conversations/*` (25+ occurrences)
   - Tests now call the actual implemented endpoints consistently
   - Example: `/conversations/:id/messages` → `/api/conversations/:id/messages`

2. **Updated API documentation** (`.docs/02-api-and-data-model.md`):
   - Updated endpoint specs to show `/api/conversations/*` prefix (8 endpoints)
   - Ensures documentation matches controller implementation
   - Aligns with project constraint: controller-level `/api` paths (no global routePrefix)

### Verification

- Tests now correctly call implemented paths (no 404s from path mismatch)
- All changes maintain consistency with controller decorators
- Documentation now accurately reflects actual API structure
- Minimal, focused changes: only paths affected, no behavioral changes

### Alignment with Constraints

✅ Follows project requirement: No global `/api` prefix, only controller-level paths  
✅ Maintains "controller-level /api paths are fine" constraint  
✅ Minimal changes focused on #269 only  
✅ Test coverage for affected paths intact  

Closes #269